### PR TITLE
Allow for more custom icons

### DIFF
--- a/src/util/patcher/channelTextAreaButtons.js
+++ b/src/util/patcher/channelTextAreaButtons.js
@@ -40,12 +40,16 @@ export const patch = (tooltipText, imgSrc, clickHandler) => {
             onMouseEnter,
             onMouseLeave
           },
-            React.createElement("img", {
-              src: imgSrc,
-              width: "24px",
-              height: "24px",
-              className: `${buttonTextAreaClasses.button} ${buttonClasses.contents} ${buttonWrapperClasses.button}`
-            })
+            imgSrc == typeof String
+              ? React.createElement("img", {
+                  src: imgSrc,
+                  width: "24px",
+                  height: "24px",
+                  className: `${buttonTextAreaClasses.button} ${buttonClasses.contents} ${buttonWrapperClasses.button}`,
+                })
+              : imgSrc() == typeof HTMLElement
+              ? imgSrc()
+              : null
           )
         )
       )


### PR DESCRIPTION
Hello and welcome back to another thrilling episode of... **"I have no idea if this works or not!"**

Basically, my goal here is that you can set more custom icons, so instead of just a link, you could instead do something like this:
```js
patch("Tooltip Text", React.createElement("svg", {
        xmlns: "http://www.w3.org/2000/svg",
        height: "24",
        viewBox: "0 0 24 24",
        width: "24",
    }, React.createElement("path", {
        d: "...",
        fill: "currentColor",
    })), (props) => {});
```
If this became a possibility, it would allow for dynamic... stuff, like colors ("currentColor").

I tried putting this functionality into the `channelTextAreaButtons` patcher, but I have no way of testing it, so make sure you test this if you decide to add it. If it doesn't work, which it probably won't, please consider taking the time to implement this yourself.